### PR TITLE
Remove file paths of missing jpegs

### DIFF
--- a/flickr_images/good_jpgs
+++ b/flickr_images/good_jpgs
@@ -5425,7 +5425,6 @@
 ./moto_x/Donkeys_Around_Town_West_Virginia_(29191696712).jpg
 ./moto_x/25442094181_41da0b150d_o_d.jpg
 ./moto_x/29193619231_8a67986024_o_d.jpg
-./moto_x/19181975258_6628ddcea4_o_d.jpg
 ./moto_x/26461492876_6f79ced3b2_o_d.jpg
 ./moto_x/25555716943_1818a04b1a_o_d.jpg
 ./moto_x/25937835290_dda97c6e8c_o_d.jpg
@@ -5457,7 +5456,6 @@
 ./moto_x/23738464443_41c80cee87_o_d.jpg
 ./moto_x/26725646586_4ee2156a04_o_d.jpg
 ./moto_x/26391812292_6418100711_o_d.jpg
-./moto_x/18747010074_161ffb3c68_o_d.jpg
 ./moto_x/25884856622_bac3ef9ea8_o_d.jpg
 ./moto_x/18874483586_8b419486fa_o_d.jpg
 ./moto_x/23704535569_75862e2585_o_d.jpg
@@ -5596,7 +5594,6 @@
 ./moto_x/25879213584_07e68e02a1_o_d.jpg
 ./moto_x/18280104093_9274f76b8c_o_d.jpg
 ./moto_x/26784637400_94361a5d95_o_d.jpg
-./moto_x/18747022814_8a49c6dfe7_o_d.jpg
 ./moto_x/Donkeys_Around_Town_Connecticut_(29191796172).jpg
 ./moto_x/Donkeys_Around_Town_Wisconsin_(28680407043).jpg
 ./moto_x/25614193913_1ec9769e73_o_d.jpg


### PR DESCRIPTION
Some jpegs referenced in good_jpegs don't have URLs.

---
Target: 19181975258_6628ddcea4_o_d
Evidence: Search "19181975258_6628ddcea4_o_d" in the GitHub search bar of this repo and you'll see it only exists in good_jpgs. Search another image ID, say, "25563861418_8d7f66072a_o" and you'll see it exists in a URL file as well as good_jpgs.

Target: 18747022814_8a49c6dfe7_o_d
Target: 18747010074_161ffb3c68_o_d